### PR TITLE
 added some things in landing page

### DIFF
--- a/components/landing/DemoSection.tsx
+++ b/components/landing/DemoSection.tsx
@@ -53,7 +53,7 @@ export default function DemoSection() {
   }, [paused])
 
   return (
-    <section className="mx-auto w-full max-w-[1400px] bg-landing px-4 py-16 md:px-6 md:py-20">
+    <section id="demo" className="mx-auto w-full max-w-[1400px] bg-landing px-4 py-16 md:px-6 md:py-20">
       <div className="relative z-10 mb-10 text-center md:mb-12">
         <h2
           className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 font-normal tracking-tight text-zinc-100"

--- a/components/landing/final-cta.tsx
+++ b/components/landing/final-cta.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { motion, useInView } from "framer-motion"
+import Link from "next/link"
 import { useRef } from "react"
 import { ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -25,27 +26,37 @@ export function FinalCTA() {
           Ready to ship faster?
         </h2>
         <p className="text-lg sm:text-xl text-zinc-400 mb-10 max-w-2xl mx-auto">
-          Join thousands of components already built with zepa. start free, no credit card  no fees required.
+          Collabrate with thousands of components already built with zepa. start free, no credit card  no fees required.
         </p>
 
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
           <Button
+            asChild
             size="lg"
             className="shimmer-btn bg-white text-zinc-950 hover:bg-zinc-200 rounded-full px-8 h-14 text-base font-medium shadow-lg shadow-white/20"
           >
-            Get Started for Free
-            <ArrowRight className="ml-2 w-5 h-5" />
+            <Link href="/components">
+              Get Started for Free
+              <ArrowRight className="ml-2 w-5 h-5" />
+            </Link>
           </Button>
           <Button
+            asChild
             variant="outline"
             size="lg"
             className="rounded-full px-8 h-14 text-base font-medium border-zinc-800 text-zinc-300 hover:bg-zinc-900 hover:text-white hover:border-zinc-700 bg-transparent"
           >
-            Talk to Sales
+            <Link
+              href="https://calendly.com/shaiksameer8921/30min"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Talk to Me
+            </Link>
           </Button>
         </div>
 
-        <p className="mt-8 text-sm text-zinc-500">Free forever for individuals. Team plans start at $29/month.</p>
+        <p className="mt-8 text-sm text-zinc-500">100% free and open source. Built for developers who care about details.</p>
       </motion.div>
     </section>
   )

--- a/components/landing/github-link.tsx
+++ b/components/landing/github-link.tsx
@@ -1,10 +1,8 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
-import { Skeleton } from "@/components/ui/skeleton"
 
 function GitHubIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
@@ -14,73 +12,82 @@ function GitHubIcon(props: React.SVGProps<SVGSVGElement>) {
   )
 }
 
-const GITHUB_REPO = "magicuidesign/magicui"
+const GITHUB_REPO = "zepa-ui/zepa.design"
 const GITHUB_URL = `https://github.com/${GITHUB_REPO}`
 
-const formatCompactCount = (value: number) => {
-  if (value >= 1000) {
-    return `${(value / 1000).toFixed(1)}k`
-  }
-
-  return value.toLocaleString()
-}
-
-async function getStarsCount() {
-  try {
-    const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}`)
-    if (!response.ok) return 0
-
-    const json: unknown = await response.json()
-    if (
-      typeof json !== "object" ||
-      json === null ||
-      !("stargazers_count" in json) ||
-      typeof json.stargazers_count !== "number"
-    ) {
-      return 0
-    }
-
-    return Number.isFinite(json.stargazers_count) ? json.stargazers_count : 0
-  } catch {
-    return 0
-  }
-}
+/*
+ * Stars count — re-enable later
+ *
+ * import { useEffect, useMemo, useState } from "react"
+ * import { Skeleton } from "@/components/ui/skeleton"
+ *
+ * const formatCompactCount = (value: number) => {
+ *   if (value >= 1000) {
+ *     return `${(value / 1000).toFixed(1)}k`
+ *   }
+ *   return value.toLocaleString()
+ * }
+ *
+ * async function getStarsCount() {
+ *   try {
+ *     const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}`)
+ *     if (!response.ok) return 0
+ *     const json: unknown = await response.json()
+ *     if (
+ *       typeof json !== "object" ||
+ *       json === null ||
+ *       !("stargazers_count" in json) ||
+ *       typeof json.stargazers_count !== "number"
+ *     ) {
+ *       return 0
+ *     }
+ *     return Number.isFinite(json.stargazers_count) ? json.stargazers_count : 0
+ *   } catch {
+ *     return 0
+ *   }
+ * }
+ *
+ * const [stars, setStars] = useState<number | null>(null)
+ *
+ * useEffect(() => {
+ *   let mounted = true
+ *   getStarsCount().then((count) => {
+ *     if (mounted) setStars(count)
+ *   })
+ *   return () => {
+ *     mounted = false
+ *   }
+ * }, [])
+ *
+ * const starsLabel = useMemo(() => {
+ *   if (stars === null) return null
+ *   return {
+ *     full: stars.toLocaleString(),
+ *     compact: formatCompactCount(stars),
+ *   }
+ * }, [stars])
+ *
+ * {starsLabel ? (
+ *   <span className="text-muted-foreground w-8 text-xs tabular-nums">
+ *     <span className="hidden sm:inline">{starsLabel.full}</span>
+ *     <span className="sm:hidden">{starsLabel.compact}</span>
+ *   </span>
+ * ) : (
+ *   <Skeleton className="h-4 w-8" />
+ * )}
+ */
 
 export function GitHubLink({ className }: { className?: string }) {
-  const [stars, setStars] = useState<number | null>(null)
-
-  useEffect(() => {
-    let mounted = true
-
-    getStarsCount().then((count) => {
-      if (mounted) setStars(count)
-    })
-
-    return () => {
-      mounted = false
-    }
-  }, [])
-
-  const starsLabel = useMemo(() => {
-    if (stars === null) return null
-    return {
-      full: stars.toLocaleString(),
-      compact: formatCompactCount(stars),
-    }
-  }, [stars])
-
   return (
-    <Button asChild size="sm" variant="ghost" className="h-8 gap-2 shadow-none">
-      <Link href={GITHUB_URL} target="_blank" rel="noreferrer" className={className} title="View on GitHub">
-        <GitHubIcon className="size-4" />
-        {starsLabel ? (
-          <span className="text-muted-foreground w-8 text-xs tabular-nums">
-            <span className="hidden sm:inline">{starsLabel.full}</span>
-            <span className="sm:hidden">{starsLabel.compact}</span>
-          </span>
-        ) : (
-          <Skeleton className="h-4 w-8" />
-        )}
+    <Button asChild size="sm" variant="ghost" className="h-8 shadow-none">
+      <Link
+        href={GITHUB_URL}
+        target="_blank"
+        rel="noreferrer"
+        className={className}
+        title="View on GitHub"
+      >
+        <GitHubIcon className="size-5 shrink-0" />
       </Link>
     </Button>
   )

--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -112,11 +112,12 @@ export function Hero() {
             </Link>
           </Button>
           <Button
+            asChild
             variant="outline"
             size="lg"
             className="rounded-full px-8 h-12 text-base font-medium border-zinc-800 text-zinc-300 hover:bg-zinc-900 hover:text-white hover:border-zinc-700 bg-transparent"
           >
-            View Demo
+            <Link href="#demo">View Demo</Link>
           </Button>
         </motion.div>
 

--- a/components/landing/navbar.tsx
+++ b/components/landing/navbar.tsx
@@ -4,14 +4,13 @@ import { useState, useRef } from "react"
 import Link from "next/link"
 import { motion } from "framer-motion"
 import { Menu, X } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { GitHubLink } from "@/components/landing/github-link"
 
 const navItems = [
   { label: "Features", href: "#features" },
   { label: "Components", href: "/components" },
+  { label: "Templates", href: "https://github.com/zepa-ui/zepa.design" },
   { label: "Docs", href: "/docs" },
-  { label: "Blog", href: "#blog" },
 ]
 
 export function Navbar() {
@@ -46,6 +45,9 @@ export function Navbar() {
               key={item.label}
               href={item.href}
               className="relative px-4 py-2 text-sm text-zinc-400 hover:text-white transition-colors"
+              {...(item.href.startsWith("http")
+                ? { target: "_blank", rel: "noreferrer" }
+                : {})}
               onMouseEnter={() => setHoveredIndex(index)}
               onMouseLeave={() => setHoveredIndex(null)}
             >
@@ -64,9 +66,6 @@ export function Navbar() {
 
         {/* CTA Buttons */}
         <div className="hidden md:flex items-center gap-3">
-          <Button variant="ghost" size="sm" className="text-zinc-400 hover:text-white hover:bg-zinc-800">
-            Sign In
-          </Button>
           <GitHubLink className="text-zinc-300 hover:text-white" />
         </div>
 
@@ -94,15 +93,15 @@ export function Navbar() {
                 key={item.label}
                 href={item.href}
                 className="px-4 py-3 text-sm text-zinc-400 hover:text-white hover:bg-zinc-800 rounded-lg transition-colors"
+                {...(item.href.startsWith("http")
+                  ? { target: "_blank", rel: "noreferrer" }
+                  : {})}
                 onClick={() => setMobileMenuOpen(false)}
               >
                 {item.label}
               </a>
             ))}
             <hr className="border-zinc-800 my-2" />
-            <Button variant="ghost" className="justify-start text-zinc-400 hover:text-white">
-              Sign In
-            </Button>
             <div className="px-1 pt-1">
               <GitHubLink className="text-zinc-300 hover:text-white" />
             </div>

--- a/components/ui/sliding-testimonial.tsx
+++ b/components/ui/sliding-testimonial.tsx
@@ -61,6 +61,16 @@ const testimonials = [
     image:
       "https://res.cloudinary.com/dy4bqxt8p/image/upload/v1781176729/core_dgrrad.png",
   },
+  {
+    name: "Avinash T",
+    profession: "Software Developer",
+    description:
+      "Clean React components with thoughtful motion. Easy to customize and impossible to tell they started as copy-paste.",
+    avatar:
+      "https://res.cloudinary.com/dy4bqxt8p/image/upload/v1781257566/Screenshot_2026-06-12_at_3.11.14_PM_ntchub.png",
+    image:
+      "https://res.cloudinary.com/dy4bqxt8p/image/upload/v1781257542/compass_ynxqk9.png",
+  },
 ]
 
 const duplicatedTestimonials = [...testimonials, ...testimonials]


### PR DESCRIPTION
Component Name
landing-page-updates (not a registry component — marketing page + navbar polish)

Description
Demo section (DemoSection.tsx)
Tabbed live hero previews: Mainframe, Vercel, Peacock, Analytics
macOS-style title bar (traffic lights + centered tabs with | separators)
Auto-rotates every 6s; pauses on hover
Blur transition between demos (unchanged)
Section title: “See [logo] in Action” with /zzepa.png inline
Subtitle matches testimonials typography
id="demo" for in-page anchor scroll
Logo marquee (logo-marquee.tsx)
Replaced placeholder company names with /l1.png–/l8.png
brightness-0 invert for dark landing (same as testimonials)
Logo size and spacing tuned
Hero (hero.tsx)
Browse Components → /components
View Demo → #demo (scrolls to DemoSection)
Navbar (navbar.tsx + github-link.tsx)
Removed Blog and Sign In
Added Templates → [github.com/zepa-ui/zepa.design](https://github.com/zepa-ui/zepa.design)
GitHub icon → [zepa-ui/zepa.design](https://github.com/zepa-ui/zepa.design) (was magicui)
Star count hidden for now; fetch/display code kept in comments for later
GitHub icon size bumped (size-5)
Final CTA (final-cta.tsx)
Get Started for Free → /components
Talk to Me → [calendly.com/shaiksameer8921/30min](https://calendly.com/shaiksameer8921/30min)
Landing page order (app/page.tsx)
Navbar → Hero → LogoMarquee → DemoSection → FeatureSection → BentoGrid → FinalCTComponent Name
landing-page-updates (not a registry component — marketing page + navbar polish)

Description
Demo section (DemoSection.tsx)
Tabbed live hero previews: Mainframe, Vercel, Peacock, Analytics
macOS-style title bar (traffic lights + centered tabs with | separators)
Auto-rotates every 6s; pauses on hover
Blur transition between demos (unchanged)
Section title: “See [logo] in Action” with /zzepa.png inline
Subtitle matches testimonials typography
id="demo" for in-page anchor scroll
Logo marquee (logo-marquee.tsx)
Replaced placeholder company names with /l1.png–/l8.png
brightness-0 invert for dark landing (same as testimonials)
Logo size and spacing tuned
Hero (hero.tsx)
Browse Components → /components
View Demo → #demo (scrolls to DemoSection)
Navbar (navbar.tsx + github-link.tsx)
Removed Blog and Sign In
Added Templates → [github.com/zepa-ui/zepa.design](https://github.com/zepa-ui/zepa.design)
GitHub icon → [zepa-ui/zepa.design](https://github.com/zepa-ui/zepa.design) (was magicui)
Star count hidden for now; fetch/display code kept in comments for later
GitHub icon size bumped (size-5)
Final CTA (final-cta.tsx)
Get Started for Free → /components
Talk to Me → [calendly.com/shaiksameer8921/30min](https://calendly.com/shaiksameer8921/30min)
Landing page order (app/page.tsx)
Navbar → Hero → LogoMarquee → DemoSection → FeatureSection → BentoGrid → FinalCT