### PR TITLE
fix: added the LICENSE for zepa

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,25 @@
-MIT License
+MIT + Commons Clause License Condition v1.0
 
-Copyright (c) 2026 Zepa UI
+Copyright (c) 2026 Shaik Sameer (Zepa UI)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+to use, copy, modify, merge, publish, and distribute the Software **as part of
+an application, website, or product**, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
+
+## Commons Clause Restriction
+
+You may use this Software, including for any commercial purpose, **so long as
+you do not sell, sublicense, or redistribute the components themselves — whether
+alone, in a bundle, or as a ported version.** This includes, without limitation,
+publishing the components (in original or modified form) as part of any other
+component library, UI kit, template, or collection.
+
+## No Warranty
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built for developers who care about details.
 - Copy & paste components
 - Motion-first interactions
 - Modern design patterns
-- Free & open source
+- Free to use
 
 Shipping new components every day.
 
@@ -43,3 +43,7 @@ Open [http://localhost:3000](http://localhost:3000).
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) or [zepa.design/docs](https://zepa.design/docs) for the full contributor guide.
+
+## License
+
+Free to use in your own projects. [MIT + Commons Clause](./LICENSE).

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -10,6 +10,8 @@ import {
   Video,
   Zap,
   AlertTriangle,
+  Scale,
+  XCircle,
 } from "lucide-react"
 import { Navbar } from "@/components/landing/navbar"
 import { Footer } from "@/components/landing/footer"
@@ -365,6 +367,73 @@ npm run test`}</pre>
             <pre className="mt-4 overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-300">
               {SHADCN_INSTALL_COMMAND}
             </pre>
+          </section>
+
+          {/* License — prominent, unmissable */}
+          <section className="rounded-3xl border-2 border-emerald-500/40 bg-gradient-to-b from-emerald-500/10 to-zinc-950 p-8 md:p-12">
+            <h2 className="mb-4 flex items-center gap-3 text-4xl font-bold tracking-tight md:text-5xl">
+              <Scale className="h-9 w-9 text-emerald-400 md:h-11 md:w-11" />
+              License
+            </h2>
+            <p className="mb-10 max-w-3xl text-2xl font-medium leading-snug text-zinc-200 md:text-3xl">
+              Build anything you want with Zepa. Just{" "}
+              <span className="text-emerald-400">don&apos;t repackage Zepa itself.</span>
+            </p>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-6">
+                <h3 className="mb-4 flex items-center gap-2 text-xl font-semibold text-emerald-400">
+                  <CheckCircle className="h-6 w-6" />
+                  You can
+                </h3>
+                <ul className="space-y-3 text-lg leading-7 text-zinc-200">
+                  <li className="flex items-start gap-3">
+                    <CheckCircle className="mt-1 h-5 w-5 shrink-0 text-emerald-400" />
+                    Use Zepa in unlimited personal & commercial projects
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <CheckCircle className="mt-1 h-5 w-5 shrink-0 text-emerald-400" />
+                    Ship it in websites, apps, SaaS, and client work
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <CheckCircle className="mt-1 h-5 w-5 shrink-0 text-emerald-400" />
+                    Copy, modify, and customize the components freely
+                  </li>
+                </ul>
+              </div>
+
+              <div className="rounded-2xl border border-red-500/30 bg-red-500/5 p-6">
+                <h3 className="mb-4 flex items-center gap-2 text-xl font-semibold text-red-400">
+                  <XCircle className="h-6 w-6" />
+                  You can&apos;t
+                </h3>
+                <ul className="space-y-3 text-lg leading-7 text-zinc-200">
+                  <li className="flex items-start gap-3">
+                    <XCircle className="mt-1 h-5 w-5 shrink-0 text-red-400" />
+                    Sell or redistribute the components themselves
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <XCircle className="mt-1 h-5 w-5 shrink-0 text-red-400" />
+                    Republish them — alone, bundled, or as a ported version
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <XCircle className="mt-1 h-5 w-5 shrink-0 text-red-400" />
+                    Include them in another component library, kit, or template
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <p className="mt-8 text-base text-zinc-400">
+              Licensed under{" "}
+              <a
+                href="https://github.com/zepa-ui/zepa.design/blob/main/LICENSE"
+                className="font-medium text-emerald-400 underline decoration-emerald-400/40 underline-offset-4 hover:decoration-emerald-400"
+              >
+                MIT + Commons Clause
+              </a>
+              . Free to use, not to resell.
+            </p>
           </section>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "zepa.ui",
   "version": "0.1.0",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/zepa-market-research-and-monetization.md
+++ b/zepa-market-research-and-monetization.md
@@ -1,0 +1,96 @@
+# Zepa — Market Research + Honest Verdict + Monetization Workflow
+
+*Prepared 2026-07-12. Brutally honest, as requested. No sugarcoating.*
+
+---
+
+## Part 1 — What you actually have (from your files + analytics)
+
+- **~30 components** across hero sections (15), navbar sections (4), and unicorn/WebGL sections (~9), built on Next.js 16 / React 19 / Tailwind v4 / Three.js / GSAP / Lenis / UnicornStudio.
+- These are **not** the commodity buttons-and-cards most libraries ship. They are 3D, WebGL, GLSL, scroll-driven, GSAP timeline components. That is genuinely harder to build and genuinely rarer.
+- Your traction is **better than you think**. Last 28 days: **1,727 page views, 246 users, avg engagement 1m53s.** `/playground/unicorn` holds users **16m 24s on average**. That last number is the single most important data point in your whole analytics dashboard — people do not spend 16 minutes on something they don't care about. Your WebGL work is the hook.
+- The bad signal, told straight: **`install_copy` fired 3 times, by 1 user** (probably you). People are *browsing*, not *adopting* yet. That's the gap you have to close — and it's a distribution/trust gap, not a quality gap.
+
+So: your "not even 500 views, embarrassing" framing is wrong. You have a product with a real hook and zero marketing. That's a normal, fixable starting point — not a failure.
+
+---
+
+## Part 2 — The market (competitors + what actually makes money)
+
+| Player | Model | Reality |
+|---|---|---|
+| **shadcn/ui** | Free, open | The default. Sets the expectation that base components are free. |
+| **React Bits** | Free (Commons Clause) | 37K GitHub stars, #2 JS Rising Stars 2025, 110+ animated components. Free and huge. This is your closest *aesthetic* competitor and it's free. |
+| **Magic UI** | Free + Pro | Large free tier, paid templates. |
+| **21st.dev** | Marketplace | 1.4M devs, 200K MAU, raised $500K. Creators monetize *through their platform*. |
+| **Aceternity UI** | Free + Pro ($169 lifetime / $129 yr) | Solo Indian founder Manu Arora. **~$60K–100K/month.** |
+| **Hover.dev / Morphin** | Free + Pro | Paid animated components — proof the paid niche exists. |
+
+**The pattern that prints money is identical every time, and you should tattoo it on your wall:**
+
+Aceternity launched with **7 free components**, no auth, no dashboard, no Stripe. Manu spent **~4 months giving away huge value**, grew Twitter/X to 20K followers, got noticed by Fireship, *then* launched Pro with an audience already waiting. Distribution first. Payment infrastructure last.
+
+**The takeaway you will not want to hear:** the people making money did NOT start by building auth + user dashboards + admin dashboards + Stripe + a registered company. They started by being impossible to ignore, for free, in public. The money plumbing came after demand existed.
+
+---
+
+## Part 3 — Would you survive? Honest answer.
+
+**Three different questions hide inside "would I survive," and they have three different answers:**
+
+1. **"Can Zepa replace a job / be my main income soon?"** — No. Not with zero audience, in a market where the default is free, competing with a free 37K-star library and a $80K/mo incumbent who has a 20K-follower head start. Betting your time on that outcome *right now* would be a mistake.
+
+2. **"Can Zepa make a real side income from premium WebGL components?"** — Yes, plausibly. The WebGL/3D niche is under-served (most libraries stop at fades and marquees), your 16-minute engagement proves the hook, and Hover/Morphin prove people pay for motion. But "real side income" here means tens to low-hundreds of dollars/month at first, growing only as fast as your audience grows.
+
+3. **"Is it worth continuing at all?"** — Yes, but reframe *why*. Even if it never becomes a business, Zepa is the best portfolio piece you could possibly have as a developer: it's live proof you can build 3D/WebGL/GSAP work most devs can't. That alone can earn you freelance/job offers worth far more than component sales. Treat revenue as the bonus, distribution as the goal, and the portfolio value as the floor you can't lose.
+
+**The single biggest risk is not your code, your pricing, or your competition. It's that you build the money machine before you build the audience, burn two months on undifferentiated plumbing (auth, dashboards, Stripe, company reg), and end up with a beautiful checkout for a store nobody visits.** That is the exact trap. Do not walk into it.
+
+**Second risk — legal/reputation.** Your pitch is "exact copy of Awwwards designs, my own code." Be careful:
+- Code you wrote is yours. Visual *design* is largely not copyrightable the same way — but "exact copy" + reselling can invite passing-off / trademark / DMCA complaints, and the dev community will *publicly roast* anything that smells like stolen design. That reputational hit is the real danger, not a lawsuit.
+- **UnicornStudio (George Hastings):** you have permission per your journal — get it **in writing** (email is fine) and keep it.
+- **Codrops:** most demos are MIT but *some* have restrictions. Check each one you converted. Attribute inspiration; never reuse their exact asset files.
+- Fix framing: sell it as **"original React implementations inspired by award-winning motion design"** — not "exact copies." Same product, defensible story.
+
+---
+
+## Part 4 — The workflow (do it in this order, not the order you listed)
+
+You listed: auth → user dashboards → admin dashboards → free/paid access → Stripe/UPI → register company. That's the **right list in the wrong order**, and half of it is premature. Here's the corrected sequence.
+
+### Phase 0 — Prove demand + build distribution (next 4–8 weeks, ~$0 infra)
+This is the phase you're skipping and it's the only one that matters right now.
+
+1. Pick your **6 strongest components** (lead with the WebGL/unicorn ones — that's your 16-minute hook). Keep them **100% free**, frictionless copy-paste.
+2. **Build in public.** Post one component demo (short screen-recording) on X/Twitter, r/reactjs, r/webdev, and dev.to **twice a week**. This is the actual job. Manu's moat was distribution, not code.
+3. Add a **"Zepa Pro — premium WebGL components, coming soon"** button + email waitlist. Ship nothing behind it yet. **Count the clicks and signups.** You already track `install_copy` — add a `pro_interest` event. *This is your survival test.* If 8 weeks of shipping can't get a few hundred signups and real install events, the answer to "would I survive" is data, not a guess.
+4. Submit to Product Hunt, `awesome-react`, `awesome-tailwind`, Bestofjs. Free distribution.
+
+### Phase 1 — Monetize with near-zero infrastructure (only after Phase 0 shows interest)
+Do **not** build auth/dashboards/Stripe yet. Use a **merchant-of-record** so you skip company registration, tax, and invoicing entirely:
+
+- **Lemon Squeezy or Polar** (global cards) and/or **Razorpay Payment Links** (India UPI). Merchant-of-record handles GST/VAT and remits tax for you — meaning **you do NOT need a registered company to start.** Sole proprietor + PAN + bank account is enough.
+- **Delivery = license key or private GitHub repo access**, emailed automatically on purchase. No login system to build.
+- **Tiering:** Free = browse + copy all non-premium components. Pro = unlock the premium WebGL/3D set (one-time **$29–$49 launch price**, or $99 lifetime later). Give a **free live demo of every paid component** (Manu does this — demo is free, code is paid). That's not copying 21st.dev, it's the standard playbook.
+- Payment choice for you specifically: **Razorpay for Indian buyers** (0% UPI under ₹2,000, best docs, ~4hr integration), **Lemon Squeezy/Polar for international** (they're merchant-of-record so no company needed). Stripe direct only later, and it charges 2% on UPI so it's the wrong first choice for India.
+
+### Phase 2 — Custom platform (only if Phase 1 makes steady money)
+*This* is where your original list belongs — and only here:
+- **Auth** (Clerk or Supabase Auth — don't hand-roll it).
+- **User dashboard** (purchased components, license keys, download history).
+- **Admin dashboard** (sales, users, which components convert).
+- **Gated registry access** (paid components served only to licensed users via your existing `/api` + shadcn registry JSON — you already have the registry plumbing).
+- **Subscriptions** via Razorpay/Stripe if you move from one-time to recurring.
+- **Register a company** (LLP or Pvt Ltd in India) — do this when revenue justifies the compliance cost, not before. Until then a merchant-of-record + sole proprietorship is correct and legal.
+
+### What you missed (add these)
+- **License / EULA** (personal vs commercial use) — non-negotiable for paid code.
+- **Refund policy** (14-day, standard for digital goods — reduces chargeback pain).
+- **Attribution + written permissions** file (UnicornStudio, Codrops per-demo licenses).
+- **Email list from day one** (your most valuable asset — owns your audience independent of any platform).
+- **Distribution/marketing** — you didn't list it at all, and it is the entire ballgame. Your bottleneck is not code. It never was.
+
+---
+
+## One-line summary
+Your product is good and your traction is real; your plan is backwards. **Stop building the checkout. Start building the audience.** Give the best stuff away in public for 8 weeks, count the clicks on a "Pro coming soon" button, and only build auth/dashboards/Stripe/company registration if that number says people will pay. The WebGL niche is real and your 16-minute engagement proves you have the hook — distribution is the only thing standing between you and revenue.


### PR DESCRIPTION
fix : updated the LICENSE added the commons clause LICENSE with the MIT one's"You can
Use Zepa in unlimited personal & commercial projects
Ship it in websites, apps, SaaS, and client work
Copy, modify, and customize the components freely
You can't
Sell or redistribute the components themselves
Republish them — alone, bundled, or as a ported version
Include them in another component library, kit, or template