### PR TITLE
 feat: added the autoplay and updated the ui of components page

### DIFF
--- a/app/components/page.tsx
+++ b/app/components/page.tsx
@@ -2,24 +2,21 @@
 
 import { useMemo, useState } from "react"
 import Link from "next/link"
-import { Menu } from "lucide-react"
 
 import { registry } from "@/content/registry"
 import { featuredSlugs } from "@/content/featured"
-import { formatCategory } from "@/lib/format-category"
 
-import { MobileSidebar } from "@/components/sidebar/mobile-sidebar"
-import { Sidebar } from "@/components/sidebar/sidebar"
+import { CategoryChips } from "@/components/showcase/category-chips"
 import { ShowcaseGrid } from "@/components/showcase/showcase-grid"
 
-// Pseudo-category — not a registry category, only used for the sidebar
-// entry and to switch `filteredItems` over to `featuredSlugs`. The label
-// shown in the UI is derived from this string by `formatCategory`.
+// Pseudo-category — not a registry category, only used for the chip row
+// and to switch `filteredItems` over to `featuredSlugs`. The label shown
+// in the UI is derived from this string by `formatCategory`.
 const FEATURED_CATEGORY = "featured-components"
 
-// Explicit sidebar order. Anything present in the registry but missing
-// from this list is appended alphabetically, so adding a new category
-// folder can never make it silently disappear from the sidebar.
+// Explicit chip order. Anything present in the registry but missing from
+// this list is appended alphabetically, so adding a new category folder
+// can never make it silently disappear.
 const CATEGORY_ORDER = [
   "hero-sections",
   "unicorn-section",
@@ -30,16 +27,13 @@ const CATEGORY_ORDER = [
 
 export default function ComponentsPage() {
   const [activeCategory, setActiveCategory] = useState(FEATURED_CATEGORY)
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   const categories = useMemo(() => {
     // widened to string: registry categories are a narrowed union, which
     // would otherwise reject the plain strings in CATEGORY_ORDER
     const present = new Set<string>(registry.map((item) => item.category))
     const ordered = CATEGORY_ORDER.filter((c) => present.has(c))
-    const rest = [...present]
-      .filter((c) => !CATEGORY_ORDER.includes(c))
-      .sort()
+    const rest = [...present].filter((c) => !CATEGORY_ORDER.includes(c)).sort()
     return [FEATURED_CATEGORY, ...ordered, ...rest]
   }, [])
 
@@ -62,53 +56,41 @@ export default function ComponentsPage() {
       : registry.filter((item) => item.category === activeCategory)
 
   return (
-    <main className="flex min-h-screen bg-black text-white">
-      <Sidebar
-        categories={categories}
-        activeCategory={activeCategory}
-        onSelect={setActiveCategory}
-        counts={categoryCounts}
-      />
-
-      <MobileSidebar
-        open={mobileMenuOpen}
-        onClose={() => setMobileMenuOpen(false)}
-        categories={categories}
-        activeCategory={activeCategory}
-        onSelect={setActiveCategory}
-        counts={categoryCounts}
-      />
-
-      <div className="flex min-h-screen flex-1 flex-col">
-        <header className="sticky top-0 z-40 flex items-center justify-between border-b border-white/10 bg-black/90 px-4 py-3 backdrop-blur-md lg:hidden">
-          <button
-            type="button"
-            onClick={() => setMobileMenuOpen(true)}
-            aria-label="Open categories menu"
-            className="rounded-lg p-2 text-white/70 transition hover:bg-white/5 hover:text-white"
-          >
-            <Menu className="size-5" />
-          </button>
-
-          <p className="text-xs font-medium uppercase tracking-wider text-white/50">
-            {formatCategory(activeCategory)}
-          </p>
-
-          <Link
-            href="/"
-            className="flex items-center rounded-lg p-1 transition hover:bg-white/5"
-          >
+    <main className="min-h-screen bg-black text-white">
+      {/* the chip row pins so switching category never means scrolling
+          back to the top of a long grid */}
+      <header className="sticky top-0 z-40 border-b border-white/10 bg-black/85 backdrop-blur-md">
+        {/* logo, chips and Docs all share one row; the chip strip takes the
+            slack and scrolls horizontally when it runs out of space */}
+        <div className="mx-auto flex w-full max-w-[2000px] items-center gap-5 px-4 py-4 lg:px-8">
+          <Link href="/" className="flex shrink-0 items-center">
             <img
               src="/zzepa.png"
               alt="Zepa UI"
-              className="h-7 w-auto max-w-[100px] object-contain"
+              className="h-7 w-auto max-w-[110px] object-contain"
             />
           </Link>
-        </header>
 
-        <div className="flex-1 overflow-y-auto p-4 lg:p-8">
-          <ShowcaseGrid items={filteredItems} />
+          <div className="min-w-0 flex-1">
+            <CategoryChips
+              categories={categories}
+              activeCategory={activeCategory}
+              onSelect={setActiveCategory}
+              counts={categoryCounts}
+            />
+          </div>
+
+          <Link
+            href="/docs"
+            className="shrink-0 rounded-full border border-white/15 px-4 py-2 text-sm text-white/70 transition hover:border-white/30 hover:text-white"
+          >
+            Docs
+          </Link>
         </div>
+      </header>
+
+      <div className="mx-auto w-full max-w-[2000px] px-4 py-8 lg:px-5">
+        <ShowcaseGrid items={filteredItems} />
       </div>
     </main>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -208,6 +208,124 @@ html.preloading .noise-overlay {
   animation: border-beam 8s linear infinite;
 }
 
+/* ── Showcase card border beam ──
+   Two conic gradients masked down to a 1px ring, counter-rotating on hover.
+   `@property` is what makes this work: without registering the angles as
+   <angle> the browser treats them as plain strings, and the keyframes snap
+   from → to instead of interpolating.
+
+   The beam is drawn on the black matte that frames the preview, never on
+   the preview itself. That matters: a light-coloured demo video used to
+   swallow the highlight when the ring sat directly on the media edge. On
+   black the same white arc reads at full strength regardless of the clip. */
+/* 0deg is the top edge, so 315deg is the top-left corner and 135deg the
+   bottom-right — the two arcs launch from diagonally opposite corners */
+@property --beam-a {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 315deg;
+}
+
+@property --beam-b {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 135deg;
+}
+
+/* Same direction, same speed, locked 180deg apart: each arc is forever
+   heading toward where the other just was and never closes the gap. Counter-
+   rotating them would make them collide twice a lap, which is not the look. */
+@keyframes card-beam-a {
+  to {
+    --beam-a: 675deg;
+  }
+}
+
+@keyframes card-beam-b {
+  to {
+    --beam-b: 495deg;
+  }
+}
+
+/* resting state: a plain hairline so the frame still has an edge */
+.card-beam {
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.07);
+  transition: box-shadow 0.4s ease;
+}
+
+/* `.card-beam` sits on the same node as `.group`, so this has to be a
+   plain :hover — `.group:hover .card-beam` would look for a descendant
+   and never match. */
+.card-beam:hover {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+    0 0 34px -12px rgba(255, 255, 255, 0.4);
+}
+
+/* Each arc is a real element, not a pseudo. Two masked conic gradients
+   stacked on ::before and ::after of the same node collapse to one visible
+   ring in Chrome — separate nodes each get their own layer. */
+.card-beam-arc {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  border-radius: inherit;
+  padding: 1px;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  /* ring-only: paint the padding box, punch out the content box */
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+}
+
+/* The lit peak sits on the gradient's own origin (0deg/360deg, with the
+   falloff wrapping either side), so each angle variable *is* the arc's
+   position on the ring — 315deg really does put it on the top-left corner. */
+.card-beam-a {
+  background: conic-gradient(
+    from var(--beam-a),
+    rgb(255, 255, 255) 0deg,
+    rgba(255, 255, 255, 0.3) 8deg,
+    transparent 34deg,
+    transparent 326deg,
+    rgba(255, 255, 255, 0.3) 352deg,
+    rgb(255, 255, 255) 360deg
+  );
+  animation: card-beam-a 4.5s linear infinite;
+}
+
+.card-beam-b {
+  background: conic-gradient(
+    from var(--beam-b),
+    rgb(255, 255, 255) 0deg,
+    rgba(255, 255, 255, 0.3) 8deg,
+    transparent 34deg,
+    transparent 326deg,
+    rgba(255, 255, 255, 0.3) 352deg,
+    rgb(255, 255, 255) 360deg
+  );
+  animation: card-beam-b 4.5s linear infinite;
+}
+
+/* the arcs *are* descendants, so both forms are valid here */
+.card-beam:hover .card-beam-arc {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-beam-arc {
+    animation: none;
+  }
+}
+
 /* Shimmer animation for CTA */
 @keyframes shimmer {
   0% {

--- a/components/showcase/category-chips.tsx
+++ b/components/showcase/category-chips.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { formatCategory } from "@/lib/format-category"
+
+interface CategoryChipsProps {
+  categories: string[]
+  activeCategory: string
+  onSelect: (category: string) => void
+  counts?: Record<string, number>
+}
+
+export function CategoryChips({
+  categories,
+  activeCategory,
+  onSelect,
+  counts,
+}: CategoryChipsProps) {
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  /* which edges are still hiding content — drives the fades so the row
+     never looks like it ends when it doesn't */
+  const [edges, setEdges] = useState({ start: false, end: false })
+
+  const measure = useCallback(() => {
+    const el = scrollerRef.current
+    if (!el) return
+    const max = el.scrollWidth - el.clientWidth
+    setEdges({
+      start: el.scrollLeft > 4,
+      end: el.scrollLeft < max - 4,
+    })
+  }, [])
+
+  useEffect(() => {
+    measure()
+    const el = scrollerRef.current
+    if (!el) return
+
+    // ResizeObserver covers the container shrinking; scroll covers the rest
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    window.addEventListener("resize", measure)
+    return () => {
+      ro.disconnect()
+      window.removeEventListener("resize", measure)
+    }
+  }, [measure, categories.length])
+
+  return (
+    <div className="relative">
+      <div
+        ref={scrollerRef}
+        onScroll={measure}
+        role="tablist"
+        aria-label="Component categories"
+        className="flex gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {categories.map((category) => {
+          const active = category === activeCategory
+          const count = counts?.[category]
+
+          return (
+            <button
+              key={category}
+              role="tab"
+              aria-selected={active}
+              onClick={() => onSelect(category)}
+              className={`flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition ${
+                active
+                  ? "border-white bg-white text-black"
+                  : "border-white/12 bg-white/[0.04] text-white/70 hover:border-white/25 hover:bg-white/[0.08] hover:text-white"
+              }`}
+            >
+              {formatCategory(category)}
+              {count !== undefined ? (
+                <span
+                  className={`rounded-full px-1.5 py-px text-[10px] tabular-nums ${
+                    active ? "bg-black/10 text-black/60" : "bg-white/10 text-white/50"
+                  }`}
+                >
+                  {count}
+                </span>
+              ) : null}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* fades sit above the row and ignore pointer events so they never
+          block a chip underneath them */}
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-black to-transparent transition-opacity duration-200 ${
+          edges.start ? "opacity-100" : "opacity-0"
+        }`}
+      />
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-black to-transparent transition-opacity duration-200 ${
+          edges.end ? "opacity-100" : "opacity-0"
+        }`}
+      />
+    </div>
+  )
+}

--- a/components/showcase/component-preview.tsx
+++ b/components/showcase/component-preview.tsx
@@ -1,13 +1,26 @@
 "use client"
 
 import Link from "next/link"
-import { useEffect, useRef, useState, useSyncExternalStore } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { Skeleton } from "@/components/ui/skeleton"
 import { useReducedMotion } from "@/hooks/use-reduced-motion"
 import { publishedDates } from "@/content/registry/published"
+import { formatCategory } from "@/lib/format-category"
+import {
+  registerPlayer,
+  reportVisibility,
+  unregisterPlayer,
+} from "@/lib/video-budget"
 
 const NEW_BADGE_WINDOW_MS = 72 * 60 * 60 * 1000 // 3 days
+
+/**
+ * How far outside the viewport a card starts downloading. Deliberately
+ * wider than the play window so the row above and below are already
+ * buffered and start instantly when they scroll in.
+ */
+const LOAD_MARGIN = "200% 0px"
 
 function isRecentlyPublished(slug: string) {
   const publishedAt = publishedDates[slug]
@@ -19,37 +32,76 @@ interface ComponentPreviewProps {
   slug: string
   title: string
   preview: string
-}
-
-const hoverNoneQuery = "(hover: none)"
-
-function subscribeToHoverNone(onStoreChange: () => void) {
-  const media = window.matchMedia(hoverNoneQuery)
-  media.addEventListener("change", onStoreChange)
-  return () => media.removeEventListener("change", onStoreChange)
-}
-
-function getHoverNoneSnapshot() {
-  return window.matchMedia(hoverNoneQuery).matches
+  category?: string
 }
 
 export function ComponentPreview({
   slug,
   title,
   preview,
+  category,
 }: ComponentPreviewProps) {
   const videoRef = useRef<HTMLVideoElement>(null)
-  const linkRef = useRef<HTMLAnchorElement>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
+
+  /* src is withheld until the card is within LOAD_MARGIN, so opening the
+     page never kicks off 40 video downloads at once */
+  const [shouldLoad, setShouldLoad] = useState(false)
   const [isVideoReady, setIsVideoReady] = useState(false)
 
-  // Skeleton stays until the video has a displayable frame (readyState >= 2).
-  // No blind timeout — with many cards loading in parallel the browser queues
-  // requests and slow cards can take a while; those are exactly the ones the
-  // skeleton exists for. Multiple events + a readyState poll cover browsers
-  // that fire events before React attaches listeners (cached videos, iOS).
-  useEffect(() => {
-    if (isVideoReady) return
+  const prefersReducedMotion = useReducedMotion()
+  const isNew = isRecentlyPublished(slug)
 
+  /* ── stage 1: attach src when the card gets close ── */
+  useEffect(() => {
+    if (shouldLoad) return
+    const el = cardRef.current
+    if (!el) return
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setShouldLoad(true)
+          io.disconnect()
+        }
+      },
+      { rootMargin: LOAD_MARGIN }
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [shouldLoad])
+
+  /* ── stage 2: report visibility; the budget decides who plays ── */
+  useEffect(() => {
+    if (!shouldLoad || prefersReducedMotion) return
+    const el = cardRef.current
+    if (!el) return
+
+    const id = Symbol(slug)
+    registerPlayer(
+      id,
+      () => void videoRef.current?.play().catch(() => {}),
+      () => videoRef.current?.pause()
+    )
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        reportVisibility(id, entry.isIntersecting ? entry.intersectionRatio : 0)
+      },
+      // a spread of thresholds so the ranking updates smoothly while scrolling
+      { threshold: [0, 0.15, 0.3, 0.5, 0.75, 1] }
+    )
+    io.observe(el)
+
+    return () => {
+      io.disconnect()
+      unregisterPlayer(id)
+    }
+  }, [shouldLoad, prefersReducedMotion, slug])
+
+  /* skeleton stays until there's a real frame to show */
+  useEffect(() => {
+    if (!shouldLoad || isVideoReady) return
     const video = videoRef.current
     if (!video) return
 
@@ -63,9 +115,10 @@ export function ComponentPreview({
     video.addEventListener("canplay", markReady)
     video.addEventListener("playing", markReady)
 
+    // some browsers fire before React attaches listeners (cached, iOS)
     const poll = window.setInterval(() => {
       if (video.readyState >= 2) markReady()
-    }, 500)
+    }, 400)
 
     return () => {
       video.removeEventListener("loadeddata", markReady)
@@ -73,101 +126,70 @@ export function ComponentPreview({
       video.removeEventListener("playing", markReady)
       window.clearInterval(poll)
     }
-  }, [isVideoReady])
-  const isTouch = useSyncExternalStore(
-    subscribeToHoverNone,
-    getHoverNoneSnapshot,
-    () => false
-  )
-
-  const prefersReducedMotion = useReducedMotion()
-  const isNew = isRecentlyPublished(slug)
-
-  // On touch devices there's no hover, so autoplay the preview once the
-  // card scrolls into view (and pause it again once it scrolls out).
-  // Skipped entirely when the user prefers reduced motion.
-  useEffect(() => {
-    if (!isTouch || prefersReducedMotion) return
-
-    const video = videoRef.current
-    const container = linkRef.current
-    if (!video || !container) return
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          video.play().catch(() => {})
-        } else {
-          video.pause()
-        }
-      },
-      { threshold: 0.5 }
-    )
-
-    observer.observe(container)
-    return () => observer.disconnect()
-  }, [isTouch, prefersReducedMotion])
-
-  const handleMouseEnter = () => {
-    if (isTouch) return
-    videoRef.current?.play().catch(() => {})
-  }
-
-  const handleMouseLeave = () => {
-    if (isTouch) return
-    const video = videoRef.current
-    if (!video) return
-    video.pause()
-    video.currentTime = 0
-  }
+  }, [shouldLoad, isVideoReady])
 
   return (
-    <Link
-      ref={linkRef}
-      href={`/components/${slug}`}
-      className="group relative block w-full overflow-hidden rounded-2xl border border-white/10"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+    /* the black matte wraps the whole card — preview *and* caption — so the
+       beam has black to ride on all the way round, and a light-coloured demo
+       can never wash it out */
+    <div
+      ref={cardRef}
+      className="group card-beam relative rounded-lg bg-black p-1.5"
     >
-      <div className="relative aspect-video overflow-hidden bg-black">
-        <video
-          ref={videoRef}
-          src={preview}
-          muted
-          loop
-          playsInline
-          preload="metadata"
-          className={`h-full w-full object-cover transition duration-300 group-hover:scale-[1.02] ${
-            isVideoReady ? "opacity-100" : "opacity-0"
-          }`}
-        />
+      <span aria-hidden className="card-beam-arc card-beam-a" />
+      <span aria-hidden className="card-beam-arc card-beam-b" />
 
-        {!isVideoReady ? (
-          <div className="absolute inset-0 p-3">
-            <Skeleton className="h-full w-full rounded-xl bg-white/10" />
-          </div>
+      <Link href={`/components/${slug}`} className="block w-full">
+        {/* the recordings are ~1280x735 (≈1.74), not 16:9 — an aspect-video
+            box makes object-cover crop the top and bottom off every clip */}
+        <div className="relative aspect-[1.74] overflow-hidden rounded">
+          {shouldLoad ? (
+            <video
+              ref={videoRef}
+              src={preview}
+              muted
+              loop
+              playsInline
+              preload="auto"
+              /* no hover scale — any zoom re-crops the frame, which is the
+                 problem the aspect fix above is solving */
+              className={`h-full w-full object-cover transition-opacity duration-500 ${
+                isVideoReady ? "opacity-100" : "opacity-0"
+              }`}
+            />
+          ) : null}
+
+          {!isVideoReady ? (
+            <div className="absolute inset-0">
+              <Skeleton className="h-full w-full rounded bg-white/10" />
+            </div>
+          ) : null}
+
+          <div className="pointer-events-none absolute inset-0 bg-black/0 transition duration-300 group-hover:bg-black/25" />
+
+          {isNew ? (
+            <span className="absolute right-3 top-3 rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-black shadow-lg">
+              New
+            </span>
+          ) : null}
+        </div>
+      </Link>
+
+      {/* caption lives inside the same black frame, separated from the
+          preview by a gap rather than by a border */}
+      <div className="flex items-center justify-between gap-3 px-1 pb-0.5 pt-2.5">
+        <Link
+          href={`/components/${slug}`}
+          className="min-w-0 truncate rounded bg-white/[0.06] px-2 py-0.5 text-[11px] font-medium text-white/85 transition hover:bg-white/[0.12] hover:text-white"
+        >
+          {title}
+        </Link>
+        {category ? (
+          <span className="shrink-0 text-[10px] text-white/30">
+            {formatCategory(category)}
+          </span>
         ) : null}
       </div>
-
-      <div className="absolute inset-0 bg-black/0 transition duration-300 group-hover:bg-black/40" />
-
-      {isNew ? (
-        <span className="absolute right-3 top-3 rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-black shadow-lg">
-          New
-        </span>
-      ) : null}
-
-      <div
-        className={`absolute inset-x-0 bottom-0 p-4 transition duration-300 ${
-          isTouch
-            ? "translate-y-0"
-            : "translate-y-full group-hover:translate-y-0"
-        }`}
-      >
-        <div className="w-fit rounded-md bg-white px-2.5 py-1 text-xs font-medium text-black">
-          {title}
-        </div>
-      </div>
-    </Link>
+    </div>
   )
 }

--- a/components/showcase/showcase-grid.tsx
+++ b/components/showcase/showcase-grid.tsx
@@ -6,17 +6,19 @@ interface ComponentItem {
   slug: string
   title: string
   preview?: string
+  category?: string
 }
 
 interface ShowcaseGridProps {
   items: ComponentItem[]
 }
 
-export function ShowcaseGrid({
-  items,
-}: ShowcaseGridProps) {
+export function ShowcaseGrid({ items }: ShowcaseGridProps) {
   return (
-    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+    /* four up from lg. At a fixed column count the only way to grow the
+       tiles is to give back gutter, so the column gap is kept tight and the
+       row gap carries the visual separation instead. */
+    <div className="grid grid-cols-1 gap-x-3 gap-y-7 sm:grid-cols-2 lg:grid-cols-4">
       {items
         .filter((item) => item.preview)
         .map((item) => (
@@ -25,6 +27,7 @@ export function ShowcaseGrid({
             slug={item.slug}
             title={item.title}
             preview={item.preview!}
+            category={item.category}
           />
         ))}
     </div>

--- a/lib/video-budget.ts
+++ b/lib/video-budget.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared playback budget for the showcase grid.
+ *
+ * Browsers cap how many videos they will decode at once — Chrome starts
+ * throttling somewhere around 8 and Safari is stricter. A 4-column grid
+ * can easily have 12+ cards on screen, so letting every visible card call
+ * play() produces stutter, fan noise, and cards that never start.
+ *
+ * Instead each card reports *how visible* it is and the budget decides who
+ * actually plays: the most-visible MAX_CONCURRENT win, everyone else is
+ * paused. Recalculated on an animation frame so a scroll burst collapses
+ * into one pass.
+ */
+
+/**
+ * The grid is 4-up, so this is "how many rows play at once".
+ * 12 = three full rows. Raising it further starts to hit the browser's
+ * own decoder limits, at which point play() resolves but nothing moves.
+ */
+const MAX_CONCURRENT = 12
+
+type Player = {
+  /** 0–1, from IntersectionObserver. 0 means offscreen. */
+  ratio: number
+  play: () => void
+  pause: () => void
+  /** whether the budget currently has it playing */
+  active: boolean
+}
+
+const players = new Map<symbol, Player>()
+let frame = 0
+
+function reconcile() {
+  frame = 0
+
+  const ranked = [...players.entries()]
+    .filter(([, p]) => p.ratio > 0)
+    .sort((a, b) => b[1].ratio - a[1].ratio)
+    .slice(0, MAX_CONCURRENT)
+
+  const winners = new Set(ranked.map(([id]) => id))
+
+  for (const [id, p] of players) {
+    const shouldPlay = winners.has(id)
+    // only touch the element when the decision actually changes
+    if (shouldPlay && !p.active) {
+      p.active = true
+      p.play()
+    } else if (!shouldPlay && p.active) {
+      p.active = false
+      p.pause()
+    }
+  }
+}
+
+function schedule() {
+  if (frame) return
+  frame = requestAnimationFrame(reconcile)
+}
+
+export function registerPlayer(
+  id: symbol,
+  play: () => void,
+  pause: () => void
+) {
+  players.set(id, { ratio: 0, play, pause, active: false })
+}
+
+export function reportVisibility(id: symbol, ratio: number) {
+  const p = players.get(id)
+  if (!p || p.ratio === ratio) return
+  p.ratio = ratio
+  schedule()
+}
+
+export function unregisterPlayer(id: symbol) {
+  players.delete(id)
+  schedule()
+}


### PR DESCRIPTION
## What

Redesigns `/components`: the left sidebar is gone, replaced by horizontal
category chips in the header, with a wider 4-up grid and viewport-budgeted
video playback.

Reference: getlayers.ai/templates

## Why

The sidebar cost ~260px of horizontal space on every viewport, which capped
preview tiles well below the size the recordings deserve. Moving category
navigation into the header reclaims that width and lets the previews carry
the page.

## Changes

**Layout**
- `app/components/page.tsx` — sidebar and `MobileSidebar` removed; sticky
  header now carries logo + category chips + Docs on one row. Container
  `max-w-[1800px] → [2000px]`, `lg:px-8 → lg:px-5`.
- `components/showcase/category-chips.tsx` **(new)** — horizontally
  scrollable chip row with edge-fade affordance driven by `scrollLeft` vs
  `scrollWidth - clientWidth`, plus a `ResizeObserver` (the strip is
  `flex-1`, so its width changes independently of the window).
- `components/showcase/showcase-grid.tsx` — 4 columns from `lg`; column gap
  tightened and row gap opened to give tiles more width at a fixed column
  count.

**Video playback**
- `lib/video-budget.ts` **(new)** — central playback budget. Cards report
  their intersection ratio; the N most-visible play and the rest pause.
  Browsers throttle past roughly a dozen simultaneously decoding videos, so
  letting every visible card call `play()` produced stutter and cards that
  never started. `MAX_CONCURRENT = 12` — three full rows at 4-up.
- `components/showcase/component-preview.tsx` — two-stage loading. Stage 1
  withholds `src` until the card is within `rootMargin: 200%`, so opening
  the page no longer kicks off ~40 downloads at once. Stage 2 reports
  visibility to the budget.

**Card treatment**
- Preview aspect `aspect-video → aspect-[1.74]`. The recordings are
  ~1280×735, not 16:9 — a 16:9 box made `object-cover` crop the top and
  bottom off every clip.
- Card is now a black matte (`bg-black p-1.5`) wrapping preview *and*
  caption, with the hover beam riding the matte's outer edge rather than
  the video's. A light-coloured demo can no longer wash the beam out.
- `app/globals.css` — `.card-beam` rewritten: two arcs as real elements
  (`.card-beam-a` / `.card-beam-b`) rather than `::before`/`::after`. Two
  masked conic gradients stacked on sibling pseudo-elements of one node
  collapse to a single visible ring in Chrome. The arcs start at diagonally
  opposite corners (315° / 135°) and travel the same direction at the same
  speed, so the 180° gap is constant and they never meet.
- Removed the hover `scale-[1.03]` on the video — any zoom re-crops the
  frame the aspect fix exists to protect.
- Caption reduced to `text-[11px]` on a slim `px-2 py-0.5` chip.

## Testing

- [x] `npm run build:registry`
- [x] `npm test`
- [x] `npm run build`
- [x] Hover a light preview and a dark one — beam should read equally on both
- [x] Scroll the grid — three rows playing, no stutter
- [x] Narrow to mobile — chips scroll with edge fades, grid collapses to 1-up

## Notes

- `components/sidebar/` is now orphaned. Left in place because
  `sidebar-search.tsx` holds the ⌘K search the new header doesn't have yet —
  worth lifting out before deleting.
- `MAX_CONCURRENT = 12` is a reasoned limit, not a measured one. If weaker
  hardware stutters, that constant is the single dial.